### PR TITLE
Fix Python CI

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -8,7 +8,9 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version:
+          - 3.7
+          - 3.8
 
     steps:
     - uses: actions/checkout@v2
@@ -22,38 +24,53 @@ jobs:
       env:
         PIP_INDEX_URL: https://pypi.pacificclimate.org/simple
       run: |
-#        sudo apt-get update
+        sudo apt-get update
         sudo apt-get install -y curl ca-certificates gnupg
         curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
         sudo su -c "echo deb http://apt.postgresql.org/pub/repos/apt `lsb_release -cs`-pgdg main >/etc/apt/sources.list.d/pgdg.list"
         sudo apt-get update
         sudo apt purge postgresql-client-14 postgresql-server-dev-all
-        sudo apt-get install postgresql-plpython-9.5 postgresql-9.5-postgis-2.4
+        sudo apt-get install -yq \
+          libpq-dev \
+          python3.7 \
+          python3.7-dev \
+          python3.7-distutils \
+          python3.7-venv \
+          python3-pip \
+          postgresql-10 \
+          postgresql-plpython-10 \
+          postgresql-10-postgis-2.4
 
     - name: Install pipenv
       run: |
         pip install -U pipenv
 
-    - id: cache-pipenv
-      uses: actions/cache@v2
-      with:
-        path: ~/.local/share/virtualenvs
-        key: ${{ runner.os }}-pipenv-${{ hashFiles('**/Pipfile.lock') }}
-
-    - name: Install dependencies if changed
-      if: steps.cache-pipenv.outputs.cache-hit != 'true' && ${{ matrix.python-version == '3.8' }}
+    - name: Create Pipenv environment
       env:
         PIP_INDEX_URL: https://pypi.pacificclimate.org/simple
       run: |
-        pipenv install --deploy --dev
+        pipenv install --dev
 
-    - name: Re-install dependencies if alternative python version
-      if: ${{ matrix.python-version != '3.8' }}
-      env:
-        PIP_INDEX_URL: https://pypi.pacificclimate.org/simple
-      run: |
-        mv Pipfile.lock do-not-use
-        pipenv install --python ${{ matrix.python-version }} --dev
+#    - id: cache-pipenv
+#      uses: actions/cache@v2
+#      with:
+#        path: ~/.local/share/virtualenvs
+#        key: ${{ runner.os }}-pipenv-${{ hashFiles('**/Pipfile.lock') }}
+#
+#    - name: Install dependencies if changed
+#      if: steps.cache-pipenv.outputs.cache-hit != 'true' && ${{ matrix.python-version == '3.8' }}
+#      env:
+#        PIP_INDEX_URL: https://pypi.pacificclimate.org/simple
+#      run: |
+#        pipenv install --deploy --dev
+#
+#    - name: Re-install dependencies if alternative python version
+#      if: ${{ matrix.python-version != '3.8' }}
+#      env:
+#        PIP_INDEX_URL: https://pypi.pacificclimate.org/simple
+#      run: |
+#        mv Pipfile.lock do-not-use
+#        pipenv install --python ${{ matrix.python-version }} --dev
 
     - name: Test with pytest (full)
       if: github.ref == 'refs/heads/master'
@@ -64,7 +81,3 @@ jobs:
       if: github.ref != 'refs/heads/master' && github.ref != 'refs/heads/crmp'
       run: |
         pipenv run pytest -m "not online and not slow" -v
-
-    - name: Check code formatting
-      run: pipenv run black --line-length=80 . --check
-

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -32,14 +32,12 @@ jobs:
         sudo apt purge postgresql-client-14 postgresql-server-dev-all
         sudo apt-get install -yq \
           libpq-dev \
-          python3.7 \
-          python3.7-dev \
-          python3.7-distutils \
-          python3.7-venv \
           python3-pip \
           postgresql-10 \
           postgresql-plpython-10 \
           postgresql-10-postgis-2.4
+        python --version
+        pip --version
 
     - name: Install pipenv
       run: |

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -43,12 +43,6 @@ jobs:
       run: |
         pip install -U pipenv
 
-#    - name: Create Pipenv environment
-#      env:
-#        PIP_INDEX_URL: https://pypi.pacificclimate.org/simple
-#      run: |
-#        pipenv install --dev
-
     - id: cache-pipenv
       uses: actions/cache@v2
       with:
@@ -61,14 +55,6 @@ jobs:
         PIP_INDEX_URL: https://pypi.pacificclimate.org/simple
       run: |
         pipenv install --deploy --dev
-
-#    - name: Re-install dependencies if alternative python version
-#      if: ${{ matrix.python-version != '3.8' }}
-#      env:
-#        PIP_INDEX_URL: https://pypi.pacificclimate.org/simple
-#      run: |
-#        mv Pipfile.lock do-not-use
-#        pipenv install --python ${{ matrix.python-version }} --dev
 
     - name: Test with pytest (full)
       if: github.ref == 'refs/heads/master'

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -43,25 +43,25 @@ jobs:
       run: |
         pip install -U pipenv
 
-    - name: Create Pipenv environment
-      env:
-        PIP_INDEX_URL: https://pypi.pacificclimate.org/simple
-      run: |
-        pipenv install --dev
-
-#    - id: cache-pipenv
-#      uses: actions/cache@v2
-#      with:
-#        path: ~/.local/share/virtualenvs
-#        key: ${{ runner.os }}-pipenv-${{ hashFiles('**/Pipfile.lock') }}
-#
-#    - name: Install dependencies if changed
-#      if: steps.cache-pipenv.outputs.cache-hit != 'true' && ${{ matrix.python-version == '3.8' }}
+#    - name: Create Pipenv environment
 #      env:
 #        PIP_INDEX_URL: https://pypi.pacificclimate.org/simple
 #      run: |
-#        pipenv install --deploy --dev
-#
+#        pipenv install --dev
+
+    - id: cache-pipenv
+      uses: actions/cache@v2
+      with:
+        path: ~/.local/share/virtualenvs
+        key: ${{ runner.os }}-pipenv-${{ hashFiles('**/Pipfile.lock') }}
+
+    - name: Install Python dependencies if changed
+      if: steps.cache-pipenv.outputs.cache-hit != 'true'
+      env:
+        PIP_INDEX_URL: https://pypi.pacificclimate.org/simple
+      run: |
+        pipenv install --deploy --dev
+
 #    - name: Re-install dependencies if alternative python version
 #      if: ${{ matrix.python-version != '3.8' }}
 #      env:

--- a/Pipfile
+++ b/Pipfile
@@ -22,8 +22,5 @@ pytest = "*"
 black = "*"
 sdpb = {editable = true, path = "."}
 
-[requires]
-python_version = "3.8"
-
 [pipenv]
 allow_prereleases = true

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,12 +1,10 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5fde437f8b6f6808df94e2b1d709dab5ac8a4a19da06bb131f7e4d46e5b0fc2c"
+            "sha256": "5a393851f4801897a00b27fc416ba0967fdb02bb85fc7619ebad64d647c9beb9"
         },
         "pipfile-spec": 6,
-        "requires": {
-            "python_version": "3.8"
-        },
+        "requires": {},
         "sources": [
             {
                 "name": "pypi",
@@ -23,11 +21,11 @@
     "default": {
         "alembic": {
             "hashes": [
-                "sha256:7c328694a2e68f03ee971e63c3bd885846470373a5b532cf2c9f1601c413b153",
-                "sha256:a9dde941534e3d7573d9644e8ea62a2953541e27bc1793e166f60b777ae098b4"
+                "sha256:6c0c05e9768a896d804387e20b299880fe01bc56484246b0dffe8075d6d3d847",
+                "sha256:ad842f2c3ab5c5d4861232730779c05e33db4ba880a08b85eb505e87c01095bc"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.7.5"
+            "version": "==1.7.6"
         },
         "attrs": {
             "hashes": [
@@ -345,7 +343,7 @@
                 "sha256:6c73e8cccc16259ea58a4d73f39fbefb6a55f641601cb7cf7f2469a5cb617caa",
                 "sha256:adc84b86555528cae237b1d8c0197dd5ffa2e4d6b7991bd95556d36b3d4a8285"
             ],
-            "markers": "python_version >= '3.7' and python_version < '4'",
+            "markers": "python_version >= '3.7' and python_full_version < '4.0.0'",
             "version": "==0.3.0a2"
         },
         "openapi-spec-validator": {
@@ -353,7 +351,7 @@
                 "sha256:16325b019dc79edf30cd25ecc2ec4b9176bea31fa2ce8da11b3cf41cc98198e9",
                 "sha256:780714eb30452e9c5e663d4ed4bbe89f7119c3811f74de9993993b79e07963c6"
             ],
-            "markers": "python_version >= '3.7' and python_version < '4'",
+            "markers": "python_version >= '3.7' and python_full_version < '4.0.0'",
             "version": "==0.5.0a1"
         },
         "packaging": {
@@ -578,7 +576,7 @@
                 "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed",
                 "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_full_version < '4.0.0'",
             "version": "==1.26.8"
         },
         "werkzeug": {
@@ -601,11 +599,11 @@
     "develop": {
         "alembic": {
             "hashes": [
-                "sha256:7c328694a2e68f03ee971e63c3bd885846470373a5b532cf2c9f1601c413b153",
-                "sha256:a9dde941534e3d7573d9644e8ea62a2953541e27bc1793e166f60b777ae098b4"
+                "sha256:6c0c05e9768a896d804387e20b299880fe01bc56484246b0dffe8075d6d3d847",
+                "sha256:ad842f2c3ab5c5d4861232730779c05e33db4ba880a08b85eb505e87c01095bc"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.7.5"
+            "version": "==1.7.6"
         },
         "asn1crypto": {
             "hashes": [
@@ -944,7 +942,7 @@
                 "sha256:6c73e8cccc16259ea58a4d73f39fbefb6a55f641601cb7cf7f2469a5cb617caa",
                 "sha256:adc84b86555528cae237b1d8c0197dd5ffa2e4d6b7991bd95556d36b3d4a8285"
             ],
-            "markers": "python_version >= '3.7' and python_version < '4'",
+            "markers": "python_version >= '3.7' and python_full_version < '4.0.0'",
             "version": "==0.3.0a2"
         },
         "openapi-spec-validator": {
@@ -952,7 +950,7 @@
                 "sha256:16325b019dc79edf30cd25ecc2ec4b9176bea31fa2ce8da11b3cf41cc98198e9",
                 "sha256:780714eb30452e9c5e663d4ed4bbe89f7119c3811f74de9993993b79e07963c6"
             ],
-            "markers": "python_version >= '3.7' and python_version < '4'",
+            "markers": "python_version >= '3.7' and python_full_version < '4.0.0'",
             "version": "==0.5.0a1"
         },
         "packaging": {
@@ -1236,7 +1234,7 @@
                 "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed",
                 "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_full_version < '4.0.0'",
             "version": "==1.26.8"
         },
         "werkzeug": {


### PR DESCRIPTION
Resolves #28 

Main problem: Python 3.6 went EOL in Dec 2021. That seems to be reflected in package installation that is (im)possible in Python 3.6 environments. Specifically, we could not get a working install of package Connexion (pinned at all times to ver 2.6.0). Two errors arose: 

- When installed in Python >= 3.7, Connexion requires OpenAPI version 3.1.x to be specified in API definition file (`sdpb/openapi/api-spec.yaml`).
- When installed in Python == 3.6, Connexion requires OpenAPI version 3.0.x.

This could have been handled with some cleverness in templating the API definition file (it is otherwise identical), but in addition, we could not get a clean install of dependencies of Connexion in a Py 3.6 environment, and the rabbit hole opened.

Solution: Ditch Python 3.6 support (that is, testing).