### PR TITLE
#81 Make "group vars in database" the only path.

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -41,7 +41,7 @@ jobs:
         sudo apt-get update
         echo "downgrading postgresql-14"
         # The version of postgresql-14 may periodically require updating. See above.
-        sudo apt-get install -yq --allow-downgrades postgresql-14=14.10-0ubuntu0.22.04.1
+        #sudo apt-get install -yq --allow-downgrades postgresql-14=14.10-0ubuntu0.22.04.1
         echo "installing postgresql-14-postgis-3"
         sudo apt-get install -yq postgresql-14-postgis-3
         echo "installing postgresql-plpython3-14"

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -41,7 +41,7 @@ jobs:
         sudo apt-get update
         echo "downgrading postgresql-14"
         # The version of postgresql-14 may periodically require updating. See above.
-        #sudo apt-get install -yq --allow-downgrades postgresql-14=14.10-0ubuntu0.22.04.1
+        sudo apt-get install -yq --allow-downgrades postgresql-14=14.11-0ubuntu0.22.04.1
         echo "installing postgresql-14-postgis-3"
         sudo apt-get install -yq postgresql-14-postgis-3
         echo "installing postgresql-plpython3-14"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,9 +4,10 @@
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
+
         {
             "name": "Python: Flask",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "module": "flask",
             "envFile": "${workspaceFolder}/.env",
@@ -17,6 +18,18 @@
             ],
             "jinja": true,
             "justMyCode": true
+        },
+        {
+            "name": "Pytest: Current File",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "pytest",
+            "console": "integratedTerminal",
+            "cwd": "${workspaceFolder}/.venv/lib/python3.11/site-packages",
+            "justMyCode": false,
+            "args": [
+                "${file}"
+            ]
         }
     ]
 }

--- a/sdpb/api/histories.py
+++ b/sdpb/api/histories.py
@@ -189,7 +189,6 @@ def single(id=None, compact=False):
 def collection(
     provinces=None,
     compact=False,
-    group_vars_in_database=True,
     include_uri=False,
 ):
     """
@@ -203,16 +202,12 @@ def collection(
         representation is returned. A compact representation:
         - omits attributes elevation, sdate, edate, tz_offset, country
         - does not put information in attribute variables
-    :param group_vars_in_database: Boolean. Perform grouping of vars by
-        history id in database or in code? In db is faster.
     :return: dict
     """
     session = get_app_session()
     with log_timing("List all histories", log=logger.debug):
         histories_etc = get_all_histories_etc(session, provinces=provinces)
-        all_vars_by_hx = get_all_vars_by_hx(
-            session, group_in_database=group_vars_in_database
-        )
+        all_vars_by_hx = get_all_vars_by_hx(session)
         with log_timing("Convert histories etc to rep", log=logger.debug):
             return collection_rep(
                 histories_etc,

--- a/sdpb/api/stations.py
+++ b/sdpb/api/stations.py
@@ -224,7 +224,6 @@ def collection(
     offset=None,
     provinces=None,
     compact=True,
-    group_vars_in_database=True,
     expand="histories",
 ):
     """
@@ -238,8 +237,6 @@ def collection(
         attribute match this value. Match means value is None or attribute
         occurs in list.
     :param compact: Boolean. Return compact rep?
-    :param group_vars_in_database: Boolean. Group variables by history id in
-        database or in code?
     :param expand: Associated items to expand. Valid values: "histories".
     :return: list of dict
     """
@@ -260,9 +257,7 @@ def collection(
                 all_histories_etc_by_station = get_all_histories_etc_by_station(
                     session, provinces=provinces
                 )
-                all_vars_by_hx = get_all_vars_by_hx(
-                    session, group_in_database=group_vars_in_database
-                )
+                all_vars_by_hx = get_all_vars_by_hx(session)
             else:
                 stations_query = (
                     session.query(

--- a/tests/performance/test_performance.py
+++ b/tests/performance/test_performance.py
@@ -32,30 +32,26 @@ def print_timing(f, label, print_example=False, **kwargs):
 
 
 # @pytest.mark.parametrize("compact", [False, True])
-# @pytest.mark.parametrize("group_vars_in_database", [False, True])
 # @pytest.mark.parametrize("provinces", ["BC"])
-# def test_histories_list(provinces, compact, group_vars_in_database):
+# def test_histories_list(provinces, compact):
 #     print_timing(
 #         histories.list,
 #         "histories",
 #         provinces=provinces,
 #         compact=compact,
-#         group_vars_in_database=group_vars_in_database,
 #     )
 #
 #
 # @pytest.mark.parametrize("compact", [False, True])
-# @pytest.mark.parametrize("group_vars_in_database", [False, True])
 # @pytest.mark.parametrize("provinces", ["BC"])
 # @pytest.mark.parametrize("expand", [None, "histories"])
-# def test_stations_list(provinces, compact, expand, group_vars_in_database):
+# def test_stations_list(provinces, compact, expand):
 #     print_timing(
 #         stations.list,
 #         "stations",
 #         # print_example=True,
 #         provinces=provinces,
 #         compact=compact,
-#         group_vars_in_database=group_vars_in_database,
 #         expand=expand,
 #     )
 #
@@ -132,7 +128,6 @@ def time_stat_values(timings):
 def print_history_timing_table(provinces, repeats=1, delay=10):
     formats = (
         "provinces!s:<5",
-        "group_vars_in_database!s:<15",
         "compact!s:<8",
         "include_uri!s:<8",
         *time_stat_formats,
@@ -145,14 +140,12 @@ def print_history_timing_table(provinces, repeats=1, delay=10):
     print_tabular(
         formats,
         compact="compact",
-        group_vars_in_database="grp vars in db",
         include_uri="incl uri",
         provinces="prov",
         **time_stat_titles,
         item_count="# items",
     )
     for nv in dict_iter(
-        ("group_vars_in_database", boolean),
         ("compact", boolean),
         ("include_uri", boolean),
     ):
@@ -171,7 +164,6 @@ def print_history_timing_table(provinces, repeats=1, delay=10):
 def print_station_timing_table(provinces, repeats=1, delay=10):
     formats = (
         "provinces!s:<5",
-        "group_vars_in_database!s:<15",
         "compact!s:<8",
         "expand!s:<10",
         *time_stat_formats,
@@ -183,14 +175,12 @@ def print_station_timing_table(provinces, repeats=1, delay=10):
     print_tabular(
         formats,
         compact="compact",
-        group_vars_in_database="grp vars in db",
         provinces="prov",
         expand="expand",
         **time_stat_titles,
         item_count="# items",
     )
     for nv in dict_iter(
-        ("group_vars_in_database", boolean),
         ("compact", boolean),
         ("expand", ("histories", None)),
     ):

--- a/tests/unit/api/test_histories.py
+++ b/tests/unit/api/test_histories.py
@@ -9,21 +9,17 @@ def test_uri(flask_app):
 
 
 @pytest.mark.parametrize("compact", [False, True])
-@pytest.mark.parametrize("group_vars_in_database", [True])
 def test_collection(
     everything_session,
     expected_history_collection,
     compact,
-    group_vars_in_database,
 ):
     """
     Test that the history collection includes exactly those histories for
     published stations.
     """
     result = sorted(
-        histories.collection(
-            compact=compact, group_vars_in_database=group_vars_in_database
-        ),
+        histories.collection(compact=compact),
         key=lambda r: r["id"],
     )
     for hx in result:

--- a/tests/unit/api/test_stations.py
+++ b/tests/unit/api/test_stations.py
@@ -10,14 +10,12 @@ def test_stations_uri(flask_app):
 
 
 @pytest.mark.parametrize("compact", [False, True])
-@pytest.mark.parametrize("group_vars_in_database", [False, True])
 @pytest.mark.parametrize("expand", [None, "histories"])
 def test_station_collection(
     flask_app,
     everything_session,
     expected_stations_collection,
     compact,
-    group_vars_in_database,
     expand,
 ):
     received = sorted(


### PR DESCRIPTION
Cleans up test errors by removing old unused path in get_all_vars_by_hx function.

Set to merge with api-prototype as that was the branch I was working from. 