### PR TITLE
#86 Post 11.4.0 bug fixes

### DIFF
--- a/sdpb/api/observations.py
+++ b/sdpb/api/observations.py
@@ -50,7 +50,8 @@ def obs_counts_by_station_query(
             ),
             History.station_id.label("station_id"),
         )
-        .join(History)
+        .select_from(ObsCountPerMonthHistory)
+        .join(History, History.id == ObsCountPerMonthHistory.history_id)
         .group_by(History.station_id)
     )
 
@@ -96,7 +97,8 @@ def climo_counts_by_station_query(session, station_ids=None, provinces=None):
             cast(func.sum(ClimoObsCount.count), sqlalchemy.Integer).label("total"),
             History.station_id.label("station_id"),
         )
-        .join(History)
+        .select_from(ClimoObsCount)
+        .join(History, History.id == ClimoObsCount.history_id)
         .group_by(History.station_id)
     )
 

--- a/sdpb/api/station_variables.py
+++ b/sdpb/api/station_variables.py
@@ -162,6 +162,7 @@ def obs_values_by_station_query(
         .filter(History.station_id == station_id)
         .join(History)
         .join(Variable)
+        .order_by(Obs.time)
     )
 
     if start_date:


### PR DESCRIPTION
Fixes #86 

- Add default sort to station observations
- Remove ambiguity from observation counts when joining on history object