### PR TITLE
Enable sqlalchemy's pre-ping feature

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -20,7 +20,7 @@ jobs:
 
     - name: Install Poetry
       run: |
-        curl -sSL https://install.python-poetry.org | python3 -
+        pip install poetry
 
     - name: Install, build and publish project
       env:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -20,7 +20,7 @@ jobs:
 
     - name: Install Poetry
       run: |
-        pip install poetry
+        pip install poetry==1.8.5
 
     - name: Install, build and publish project
       env:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -49,7 +49,7 @@ jobs:
 
     - name: Install Poetry
       run: |
-        pip install poetry
+        pip install poetry==1.8.5
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -41,7 +41,7 @@ jobs:
         sudo apt-get update
         echo "downgrading postgresql-14"
         # The version of postgresql-14 may periodically require updating. See above.
-        #sudo apt-get install -yq --allow-downgrades postgresql-14=14.11-0ubuntu0.22.04.1
+        sudo apt-get install -yq --allow-downgrades postgresql-14=14.17-0ubuntu0.22.04.1
         echo "installing postgresql-14-postgis-3"
         sudo apt-get install -yq postgresql-14-postgis-3
         echo "installing postgresql-plpython3-14"

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -41,7 +41,7 @@ jobs:
         sudo apt-get update
         echo "downgrading postgresql-14"
         # The version of postgresql-14 may periodically require updating. See above.
-        sudo apt-get install -yq --allow-downgrades postgresql-14=14.11-0ubuntu0.22.04.1
+        #sudo apt-get install -yq --allow-downgrades postgresql-14=14.11-0ubuntu0.22.04.1
         echo "installing postgresql-14-postgis-3"
         sudo apt-get install -yq postgresql-14-postgis-3
         echo "installing postgresql-plpython3-14"

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -49,7 +49,7 @@ jobs:
 
     - name: Install Poetry
       run: |
-        curl -sSL https://install.python-poetry.org | python3 -
+        pip install poetry
 
     - name: Install dependencies
       run: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,6 @@ ENV LANG=C.UTF-8
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get -yq install \
-        curl \
         libpq-dev \
         python3 \
         python3-dev \
@@ -55,7 +54,7 @@ ENV PATH=${USER_DIR}/.local/bin:${PATH}
 
 RUN \
     # Install Poetry && \
-    curl -sSL https://install.python-poetry.org | python3 - && \
+    pip install poetry && \
     # Install the project && \
     poetry install
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,7 +54,7 @@ ENV PATH=${USER_DIR}/.local/bin:${PATH}
 
 RUN \
     # Install Poetry && \
-    pip install poetry && \
+    pip install poetry==1.8.5 && \
     # Install the project && \
     poetry install
 

--- a/sdpb/__init__.py
+++ b/sdpb/__init__.py
@@ -37,6 +37,9 @@ def create_app(config_override={}):
         SQLALCHEMY_TRACK_MODIFICATIONS=False,
         SQLALCHEMY_ECHO=False,
         COMPRESS_ALGORITHM="gzip",
+        SQLALCHEMY_ENGINE_OPTIONS={
+            "pool_pre_ping": True,
+        },
     )
     flask_app.config.update(config_override)
     compress.init_app(flask_app)


### PR DESCRIPTION
Enable's SQLAlchemy's pre-ping feature, which sends a trivial test query (`SELECT 1`) to test whether the database connection is open and reconnects if needed before sending a real query. This reduces the number of errors caused by database disconnections.

[Here](https://beehive.pacificclimate.org/weather-anomaly-viewer/app) is a demo weather anomaly running against this backed, but there should not be anything to see. 

Also addresses a couple build errors:

- updates postgresql packages 
- installs `poetry` via `pip`, since (for unknown reasons) the preferred installation via curl is not working in github workflows right now. It works everywhere else.

resolves #89 