### PR TITLE
add SQLAlchemy connection pool customisation, readyz route

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,6 +51,7 @@ ENV LANG=C.UTF-8
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get -yq install \
+        curl \
         libpq5 \
         python3 \
         postgresql-client && \
@@ -80,6 +81,9 @@ WORKDIR ${USER_DIR}
 ENV PATH=${USER_DIR}/.venv/bin:${PATH}
 
 EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+    CMD curl -f http://localhost:8000/readyz || exit 1
 
 # gunicorn.conf is set up so that Gunicorn settings are set by environment variables.
 # Gunicorn setting [setting] is set by env var GUNICORN_[setting].

--- a/sdpb/__init__.py
+++ b/sdpb/__init__.py
@@ -1,8 +1,12 @@
 import logging
 import os
+from typing import Any
 import connexion
+from flask import jsonify, request
 from flask_compress import Compress
 from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import text
+from sqlalchemy.pool import NullPool
 from starlette.middleware.cors import CORSMiddleware
 
 logger = logging.getLogger(__name__)
@@ -27,6 +31,31 @@ app_db = None
 compress = Compress()
 
 
+def _build_engine_options() -> dict[str, Any]:
+    """Build SQLAlchemy engine options from environment variables.
+
+    Set SQLALCHEMY_POOL_CLASS=null to use NullPool (recommended when deploying
+    behind pgbouncer). Optional pool tuning via SQLALCHEMY_POOL_SIZE,
+    SQLALCHEMY_MAX_OVERFLOW, SQLALCHEMY_POOL_TIMEOUT, SQLALCHEMY_POOL_RECYCLE.
+    """
+    if os.getenv("SQLALCHEMY_POOL_CLASS", "").lower() == "null":
+        return {"poolclass": NullPool}
+
+    options: dict[str, Any] = {"pool_pre_ping": True}
+
+    for env_var, key, cast in [
+        ("SQLALCHEMY_POOL_SIZE", "pool_size", int),
+        ("SQLALCHEMY_MAX_OVERFLOW", "max_overflow", int),
+        ("SQLALCHEMY_POOL_TIMEOUT", "pool_timeout", float),
+        ("SQLALCHEMY_POOL_RECYCLE", "pool_recycle", float),
+    ]:
+        val = os.getenv(env_var)
+        if val is not None:
+            options[key] = cast(val)
+
+    return options
+
+
 def create_app(config_override={}):
     global connexion_app, flask_app, app_db
     connexion_app = connexion.FlaskApp(__name__, specification_dir="openapi/")
@@ -39,14 +68,28 @@ def create_app(config_override={}):
         SQLALCHEMY_TRACK_MODIFICATIONS=False,
         SQLALCHEMY_ECHO=False,
         COMPRESS_ALGORITHM="gzip",
-        SQLALCHEMY_ENGINE_OPTIONS={
-            "pool_pre_ping": True,
-        },
+        SQLALCHEMY_ENGINE_OPTIONS=_build_engine_options(),
     )
     flask_app.config.update(config_override)
     compress.init_app(flask_app)
 
     app_db = SQLAlchemy(flask_app)
+
+    @flask_app.route("/readyz")
+    def readyz():
+        status = {"status": "ok"}
+        http_status = 200
+        if request.args.get("verbose", "").lower() in ("1", "true", "yes"):
+            try:
+                get_app_session().execute(text("SELECT 1"))
+                status["db"] = "ok"
+            except Exception as e:
+                status["status"] = "error"
+                status["db"] = str(e)
+                http_status = 503
+        response = jsonify(status)
+        response.cache_control.no_store = True
+        return response, http_status
 
     @flask_app.errorhandler(Exception)
     def log_unhandled_exception(e):


### PR DESCRIPTION
Follows a similar template to https://github.com/pacificclimate/climate-explorer-backend/pull/256

- Add some pool customisation via Environment Variables
- Add readyz healthcheck route
- Use healtcheck route in docker image